### PR TITLE
Fix wrapping preview text

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	parser.Usage = "[OPTIONS] QUERY..."
 	args, err := parser.Parse()
 	if err != nil {
-        fmt.Fprintln(os.Stderr, "Argument parsing failed.")
+		fmt.Fprintln(os.Stderr, "Argument parsing failed.")
 		os.Exit(1)
 	}
 
@@ -90,7 +90,7 @@ func main() {
 				return fmt.Sprintf(
 					"%s\n\n%s\n\n%s",
 					result.Query.Search[i].Title,
-					runewidth.Wrap(result.Query.Search[i].Snippet, w),
+					runewidth.Wrap(result.Query.Search[i].Snippet, w/2-5),
 					humanize.Time(result.Query.Search[i].Timestamp),
 				)
 			},


### PR DESCRIPTION
The argument width of function f, which is taken as the argument of function `fuzzyfinder.WithPreviewWindow`, is the width of the entire terminal.

> width and height are the size of the terminal so that you can use these to adjust a preview content. 

https://pkg.go.dev/github.com/ktr0731/go-fuzzyfinder#WithPreviewWindow

The width of preview window can be calculated excluding vertical lines `|` and spaces for padding. [source](https://github.com/ktr0731/go-fuzzyfinder/blob/30689be04cb198f3b9613c8b93884ea451517c6b/fuzzyfinder.go#L347)